### PR TITLE
GEM#2239: Replace AsyncEnumerator with C# 8.0 Async Streams

### DIFF
--- a/Stark.MessageBroker.Tests/MessageBrokerTests.cs
+++ b/Stark.MessageBroker.Tests/MessageBrokerTests.cs
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using NUnit.Framework;
 using Stark.MessageBroker.Tests.Messages;
 using Stark.MessageBroker.Tests.Mocks;
@@ -358,7 +358,7 @@ namespace Stark.MessageBroker.Tests
             for (var idx = 1; idx <= iteration; idx++) posts.Add(idx);
 
             await posts.ParallelForEachAsync(async post => await broker.PostAsync(new FooMessage()),
-                                             maxDegreeOfParalellism: 100);
+                                             maxDegreeOfParallelism: 100);
 
             Assert.That(result.Count, Is.EqualTo(2*iteration));
             Assert.That(result.Count(p => p.Contains("Action Executed")), Is.EqualTo(iteration));

--- a/Stark.MessageBroker/MessageBroker.cs
+++ b/Stark.MessageBroker/MessageBroker.cs
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Async;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dasync.Collections;
 using Stark.MessageBroker.Logging;
 
 
@@ -170,7 +170,7 @@ namespace Stark.MessageBroker
                                                         {
                                                             if (action.Func is Func<Task> f) await f();
                                                         },
-                                                        maxDegreeOfParalellism: 100);
+                                                        maxDegreeOfParallelism: 100);
             } else {
                 if (Actions.TryGetValue(messageType, out actionValues)) {
                     // todo: Would like to lock to protect against changes to the collection...
@@ -179,7 +179,7 @@ namespace Stark.MessageBroker
                                                                 if (action.Func is Func<Task> f) await f();
 
                                                             },
-                                                            maxDegreeOfParalellism: 100);
+                                                            maxDegreeOfParallelism: 100);
                 } else {
                     throw new MessageBrokerException($"Failed to get Actions for {messageType}! Actions not processed.");
                 }
@@ -219,7 +219,7 @@ namespace Stark.MessageBroker
                                                             if (action.Func is Func<Task> f) await f();
                                                             if (action.Func is Func<T, Task> fd) await fd(message);
                                                         },
-                                                        maxDegreeOfParalellism: 100);
+                                                        maxDegreeOfParallelism: 100);
             } else {
                 if (Actions.TryGetValue(messageType, out actionValues)) {
                     // todo: Would like to lock to protect against changes to the collection...
@@ -228,7 +228,7 @@ namespace Stark.MessageBroker
                                                                 if (action.Func is Func<Task> f) await f();
                                                                 if (action.Func is Func<T, Task> fd) await fd(message);
                                                             },
-                                                            maxDegreeOfParalellism: 100);
+                                                            maxDegreeOfParallelism: 100);
                 } else {
                     throw new MessageBrokerException($"Failed to get Actions for {messageType}! Actions not processed.");
                 }

--- a/Stark.MessageBroker/Stark.MessageBroker.csproj
+++ b/Stark.MessageBroker/Stark.MessageBroker.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncEnumerator" Version="2.2.2" />
+    <PackageReference Include="AsyncEnumerator" Version="3.1.0" />
     <PackageReference Include="LibLog" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
StarkRFID/Gemini#2239

Updated the `AsyncEnumerator` package to from 2.2.0 to 3.1.0.

Just a few code changes required since parallelism is apparently hard to spell.

![image](https://media1.tenor.com/images/c12a840296e43de32a67bd5b581e5b3b/tenor.gif)
