### PR TITLE
Rename Default Namespace

### DIFF
--- a/Stark.MessageBroker.Tests/MessageBrokerTests.cs
+++ b/Stark.MessageBroker.Tests/MessageBrokerTests.cs
@@ -10,10 +10,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dasync.Collections;
 using NUnit.Framework;
-using Stark.MessageBroker.Tests.Messages;
-using Stark.MessageBroker.Tests.Mocks;
+using Stark.Messaging.Tests.Messages;
+using Stark.Messaging.Tests.Mocks;
 
-namespace Stark.MessageBroker.Tests
+namespace Stark.Messaging.Tests
 {
     [TestFixture]
     [Category("Service")]

--- a/Stark.MessageBroker.Tests/Messages/Bar.cs
+++ b/Stark.MessageBroker.Tests/Messages/Bar.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class Bar
     {

--- a/Stark.MessageBroker.Tests/Messages/BarMessage.cs
+++ b/Stark.MessageBroker.Tests/Messages/BarMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class BarMessage : Message<Bar>
     {

--- a/Stark.MessageBroker.Tests/Messages/DoNotRunMessage.cs
+++ b/Stark.MessageBroker.Tests/Messages/DoNotRunMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     /// <summary>
     /// A generic message handled by the Message Broker.

--- a/Stark.MessageBroker.Tests/Messages/DoNotRunWithData.cs
+++ b/Stark.MessageBroker.Tests/Messages/DoNotRunWithData.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class DoNotRunWithData : Message<Foo>
     {

--- a/Stark.MessageBroker.Tests/Messages/Foo.cs
+++ b/Stark.MessageBroker.Tests/Messages/Foo.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class Foo
     {

--- a/Stark.MessageBroker.Tests/Messages/FooBar.cs
+++ b/Stark.MessageBroker.Tests/Messages/FooBar.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class FooBar
     {

--- a/Stark.MessageBroker.Tests/Messages/FooBarMessage.cs
+++ b/Stark.MessageBroker.Tests/Messages/FooBarMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     public class FooBarMessage : Message<FooBar>
     {

--- a/Stark.MessageBroker.Tests/Messages/FooMessage.cs
+++ b/Stark.MessageBroker.Tests/Messages/FooMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     /// <summary>
     /// A message containing data handled by the Message Broker.

--- a/Stark.MessageBroker.Tests/Messages/GenericMessage.cs
+++ b/Stark.MessageBroker.Tests/Messages/GenericMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Messages
+namespace Stark.Messaging.Tests.Messages
 {
     /// <summary>
     /// A generic message handled by the Message Broker.

--- a/Stark.MessageBroker.Tests/Mocks/LogLevel.cs
+++ b/Stark.MessageBroker.Tests/Mocks/LogLevel.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker.Tests.Mocks
+namespace Stark.Messaging.Tests.Mocks
 {
     public enum LogLevel
     {

--- a/Stark.MessageBroker.Tests/Mocks/LogServiceMock.cs
+++ b/Stark.MessageBroker.Tests/Mocks/LogServiceMock.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace Stark.MessageBroker.Tests.Mocks
+namespace Stark.Messaging.Tests.Mocks
 {
     internal class LogServiceMock
     {

--- a/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
+++ b/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
@@ -14,6 +14,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <IsPackable>false</IsPackable>
+    <RootNamespace>Stark.Messaging.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
+++ b/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 

--- a/Stark.MessageBroker.Tests/TestableMessageBroker.cs
+++ b/Stark.MessageBroker.Tests/TestableMessageBroker.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Stark.MessageBroker.Tests
+namespace Stark.Messaging.Tests
 {
     /// <summary>
     /// This wrapper should only be used in unit tests to provide access

--- a/Stark.MessageBroker/IMessage.cs
+++ b/Stark.MessageBroker/IMessage.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker
+namespace Stark.Messaging
 {
     /// <summary>
     /// Messages handled by the Message Broker.

--- a/Stark.MessageBroker/IMessageBroker.cs
+++ b/Stark.MessageBroker/IMessageBroker.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace Stark.MessageBroker
+namespace Stark.Messaging
 {
     public interface IMessageBroker
     {

--- a/Stark.MessageBroker/Message.cs
+++ b/Stark.MessageBroker/Message.cs
@@ -3,7 +3,7 @@
 // Unauthorized copying of this file, via any medium, is strictly prohibited.
 // ------------------------------------------------------------------------------
 
-namespace Stark.MessageBroker
+namespace Stark.Messaging
 {
     /// <inheritdoc />
     /// <summary>

--- a/Stark.MessageBroker/MessageBroker.cs
+++ b/Stark.MessageBroker/MessageBroker.cs
@@ -9,10 +9,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dasync.Collections;
-using Stark.MessageBroker.Logging;
+using Stark.Messaging.Logging;
 
 
-namespace Stark.MessageBroker
+namespace Stark.Messaging
 {
     public class MessageBroker : IMessageBroker
     {

--- a/Stark.MessageBroker/MessageBrokerException.cs
+++ b/Stark.MessageBroker/MessageBrokerException.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace Stark.MessageBroker
+namespace Stark.Messaging
 {
     [Serializable]
     public class MessageBrokerException : Exception

--- a/Stark.MessageBroker/Stark.MessageBroker.csproj
+++ b/Stark.MessageBroker/Stark.MessageBroker.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncEnumerator" Version="3.1.0" />
+    <PackageReference Include="AsyncEnumerator" Version="4.0.1" />
     <PackageReference Include="LibLog" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Stark.MessageBroker/Stark.MessageBroker.csproj
+++ b/Stark.MessageBroker/Stark.MessageBroker.csproj
@@ -16,6 +16,7 @@
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+    <RootNamespace>Stark.Messaging</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Renames the default namespace from `Stark.MessageBroker` to `Stark.Messaging`, removing the conflict between namespace and broker class.

In addition, the `AsyncEnumerator` NuGet package was updated to v4.0.1.