### PR TITLE
NONE: Serialize Access to Subscription Collection

### DIFF
--- a/Stark.MessageBroker/MessageBroker.cs
+++ b/Stark.MessageBroker/MessageBroker.cs
@@ -172,10 +172,6 @@ namespace Stark.Messaging
                 return;
             }
 
-            // I removed the second attempt to get the values since the collection
-            // is being locked before it's accessed. We probably don't even need a 
-            // concurrent dictionary, but there's no harm in using one. If you think 
-            // a second attempt should be made, let me know in the PR and I'll update.
             IList<(object Func, string Name)> subscriptions = null;
             await UseLockAsync(() =>
                                {
@@ -221,10 +217,6 @@ namespace Stark.Messaging
                 return;
             }
 
-            // I removed the second attempt to get the values since the collection
-            // is being locked before it's accessed. We probably don't even need a 
-            // concurrent dictionary, but there's no harm in using one. If you think 
-            // a second attempt should be made, let me know in the PR and I'll update.
             IList<(object Func, string Name)> subscriptions = null;
             await UseLockAsync(() =>
                                {


### PR DESCRIPTION
### Summary of Changes Proposed in this Request

Introduces a `SemaphoreSlim` to serialize access to the subscriptions collection. This allows the collection to be protected when subscriptions are being executed due to a post. 

A single semaphore is used for all message types, which could potentially affect performance in situations where the subscriptions are heavily modified. In our uses, that's not generally the case, as the subscriptions are added during startup or other initialization and remain for the life of the application. 

To prevent performance issues when executing subscriptions, the list of subscriptions for the given message type is duplicated and the copy is used for the execution. The lock is obtained only during this process, so there could be a slight performance hit initially, but it would not affect the ability of two different messages from executing simultaneously.