### PR TITLE
GEM#4252: Update to .NET 6

### DIFF
--- a/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
+++ b/Stark.MessageBroker.Tests/Stark.MessageBroker.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <PackageId>Stark.MessageBroker.Tests</PackageId>
     <PackageVersion>1.0.0</PackageVersion>
@@ -18,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Stark.MessageBroker/Stark.MessageBroker.csproj
+++ b/Stark.MessageBroker/Stark.MessageBroker.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncEnumerator" Version="4.0.1" />
-    <PackageReference Include="LibLog" Version="5.0.6">
+    <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
+    <PackageReference Include="LibLog" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/azure/pr-validation-pipelines.yml
+++ b/azure/pr-validation-pipelines.yml
@@ -41,6 +41,13 @@ steps:
 #     nuGetServiceConnections: 'stark-github-packages'
 #     forceReinstallCredentialProvider: true
 
+- task: UseDotNet@2
+  displayName: "Install .NET 6.0 SDK"
+  inputs:
+    version: 6.x
+    performMultiLevelLookup: true
+    includePreviewVersions: false
+
 - task: DotNetCoreCLI@2
   displayName: dotnet restore
   inputs:

--- a/azure/production-pipelines.yml
+++ b/azure/production-pipelines.yml
@@ -14,7 +14,7 @@ resources:
 
 variables:
   # Current product version
-  starkVer: 2.0.2
+  starkVer: 2.0.3
 
   gitTag: 'MSGBKR-v$(starkVer).$(Build.BuildId)'
   messageBrokerProject: 'Stark.MessageBroker/Stark.MessageBroker.csproj'
@@ -58,6 +58,13 @@ stages:
       inputs:
         nuGetServiceConnections: 'stark-github-packages'
         forceReinstallCredentialProvider: true
+
+    - task: UseDotNet@2
+      displayName: "Install .NET 6.0 SDK"
+      inputs:
+        version: 6.x
+        performMultiLevelLookup: true
+        includePreviewVersions: false
 
     - task: DotNetCoreCLI@2
       displayName: dotnet restore


### PR DESCRIPTION
Updates the test project to .NET 6, as .NET Core 2.1 is no longer supported by Azure DevOps (at least in `windows-latest` images). Updated NuGet packages as well to latest. 